### PR TITLE
Stringlit Analyzer fix-issue#1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,4 @@ ModelManifest.xml
 
 # FAKE - F# Make
 .fake/
+*.ini

--- a/COMPILER/Lexical Analyzer/Sample.cs
+++ b/COMPILER/Lexical Analyzer/Sample.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+//using System.Threading.Tasks;
 
 namespace Lexical_Analyzer
 {


### PR DESCRIPTION
**Stringlit Analyzer issues to fix:**
- Returns invalid token after any character even with proper delimiter.
- Incapable of reading escape sequences. (e.g. "\n", "\t", "\").

Assigning @shinzangetsu to see other issues regarding stringlit analyzer.
NOTE: Comment below if found any issues.
